### PR TITLE
GeneralSimpleProductBuilder added

### DIFF
--- a/index.php
+++ b/index.php
@@ -49,7 +49,28 @@ $generalData =
             'short' => 'i am the short desc'
         ],
         'variations' => [
-            'title' => 'FFF',
+            [
+                'title' => 'VARIATION 1',
+                'price' => 150,
+                'special_price'=>100,
+                'special_price_expiry'=>'2020-03-14 11:53:22',
+                'special_price_active'=>false,
+                'vat'=>20,
+            ],[
+                'title' => 'VARIATION 2',
+                'price' => 150,
+                'special_price'=>100,
+                'special_price_expiry'=>'2020-03-14 11:53:22',
+                'special_price_active'=>false,
+                'vat'=>20,
+            ],[
+                'title' => 'VARIATION 3',
+                'price' => 150,
+                'special_price'=>100,
+                'special_price_expiry'=>'2020-03-14 11:53:22',
+                'special_price_active'=>false,
+                'vat'=>20,
+            ]
         ]
     ];
 
@@ -58,12 +79,51 @@ $general = $director->buildGeneralProduct(
     $generalData
 );
 
-$v = new \vbpupil\Variation\SimpleVariation(
+
+$generalSimpleData =
     [
-        'title' => 'FFF',
-    ]
+        'product_name' => 'PS4 v5',
+        'descriptions' => [
+            'long' => 'i am the long desc',
+            'short' => 'i am the short desc'
+        ],
+        'variations' => [
+            [
+                'title' => 'VARIATION 1',
+                'price' => 150,
+                'special_price'=>100,
+                'special_price_expiry'=>'2020-03-14 11:53:22',
+                'special_price_active'=>false,
+                'vat'=>20,
+            ],[
+                'title' => 'VARIATION 2',
+                'price' => 150,
+                'special_price'=>100,
+                'special_price_expiry'=>'2020-03-14 11:53:22',
+                'special_price_active'=>false,
+                'vat'=>20,
+            ],[
+                'title' => 'VARIATION 3',
+                'price' => 150,
+                'special_price'=>100,
+                'special_price_expiry'=>'2020-03-14 11:53:22',
+                'special_price_active'=>false,
+                'vat'=>20,
+            ]
+        ]
+    ];
+
+$generalSimple = $director->buildGeneralProduct(
+    new \vbpupil\Builder\GeneralSimpleProductBuilder(),
+    $generalSimpleData
 );
-$general->variations->addItem($v);
+
+//$v = new \vbpupil\Variation\SimpleVariation(
+//    [
+//        'title' => 'FFF',
+//    ]
+//);
+//$general->variations->addItem($v);
 
 //dump($general->variations->getItem(1));
 
@@ -74,8 +134,7 @@ $general->variations->addItem($v);
 
 //dump($simple);
 dump($general);
-$b = $general->variations->getItem('0');
-var_dump($b);
+dump($generalSimple);
 //BUILDER END
 
 

--- a/src/Builder/GeneralProductBuilder.php
+++ b/src/Builder/GeneralProductBuilder.php
@@ -8,6 +8,8 @@ use Vbpupil\Collection\Collection;
 use vbpupil\Product\Product;
 
 /**
+ * A GENERAL PRODUCT IS A PRODUCT WITH MULTIPLE VARIATIONS
+ *
  * Class GeneralProductBuilder
  * @package vbpupil\Builder
  */

--- a/src/Builder/GeneralSimpleProductBuilder.php
+++ b/src/Builder/GeneralSimpleProductBuilder.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace vbpupil\Builder;
+
+
+use Vbpupil\Collection\Collection;
+use vbpupil\Product\Product;
+
+/**
+ * A GENERAL SIMPLE PRODUCT HAS ONE VARIATION
+ *
+ * Class GeneralSimpleProductBuilder
+ * @package vbpupil\Builder
+ */
+class GeneralSimpleProductBuilder extends GeneralProductBuilder implements ProductBuilderInterface
+{
+}

--- a/src/Builder/ProductDirector.php
+++ b/src/Builder/ProductDirector.php
@@ -15,7 +15,7 @@ class ProductDirector
         $p->setDescriptions(new Collection());
         $p->setProductImages(new Collection());
 
-        $this->populateData($p, $data);
+        $this->populateData($p, $data, $product);
 
         unset($p->variations);
 
@@ -31,14 +31,14 @@ class ProductDirector
         $p->setProductImages(new Collection());
 
 
-        $this->populateData($p, $data);
+        $this->populateData($p, $data, $product);
 
 
         return $p;
     }
 
 
-    protected function populateData(&$p, $data)
+    protected function populateData(&$p, $data, $originalObject)
     {
         if (isset($data['live']) && is_bool($data['live'])) {
             $p->setLive($data['live']);
@@ -86,14 +86,19 @@ class ProductDirector
                 );
                 $tmpVariation->setPrice(
                     new \vbpupil\Price\SinglePrice([
-                            'vatRate' => 20,
-                            'exVat' => intval($v['price']),
-                            'currency' => 'GBP',
-                            'specialPriceActive' => $v['special_price_active'],
-                            'specialPriceActiveUntil' => $v['special_price_expiry'],
-                            'specialPrice' => intval($v['special_price'])
-                        ])
+                        'vatRate' => 20,
+                        'exVat' => intval($v['price']),
+                        'currency' => 'GBP',
+                        'specialPriceActive' => $v['special_price_active'],
+                        'specialPriceActiveUntil' => $v['special_price_expiry'],
+                        'specialPrice' => intval($v['special_price'])
+                    ])
                 );
+
+                if ($originalObject instanceof GeneralSimpleProductBuilder) {
+                    $p->variations->addItem($tmpVariation);
+                    break;
+                }
 
                 $p->variations->addItem($tmpVariation);
             }

--- a/src/Builder/SimpleProductBuilder.php
+++ b/src/Builder/SimpleProductBuilder.php
@@ -8,6 +8,8 @@ use Vbpupil\Collection\Collection;
 use vbpupil\Product\Product;
 
 /**
+ * A SIMPLE PRODUCT IS JUST THE PRODUCT - IE NO VARIANTS
+ *
  * Class SimpleProductBuilder
  * @package vbpupil\Builder
  */
@@ -73,7 +75,8 @@ class SimpleProductBuilder implements ProductBuilderInterface
      */
     public function setVariations(Collection $variations)
     {
-        $this->product->setVariations($variations);
+        //no variations exist for a simple product
+//        $this->product->setVariations($variations);
     }
 
     /**


### PR DESCRIPTION
introduced the concept of a new GeneralSimpleProductBuilder. So the following now applies:

SimpleProductBuilder - prepares a product with **NO** variants
GeneralSimpleProductBuilder - prepares a product with **ONE** variant 
GeneralProductBuilder - prepares a product with **MANY** variant